### PR TITLE
Rock Blocks impletment isPassable so animals don't get stuck

### DIFF
--- a/src/main/java/mcjty/immcraft/blocks/foliage/RockBlock.java
+++ b/src/main/java/mcjty/immcraft/blocks/foliage/RockBlock.java
@@ -72,6 +72,12 @@ public class RockBlock extends GenericImmcraftBlock {
         return false;
     }
 
+    @Override
+    public boolean isPassable(IBlockAccess worldIn, BlockPos pos)
+    {
+        return true;
+    }
+
 //@todo
 //    @Override
 //    public boolean isBlockSolid(IBlockAccess worldIn, BlockPos pos, EnumFacing side) {


### PR DESCRIPTION
This should fix https://github.com/McJty/ImmersiveCraft/issues/35 for 1.12.2. I did not see this happening with stick clusters, so I did not change anything there.